### PR TITLE
Feature/117: capitalize titles and discard descriptions

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yaml
+++ b/.github/ISSUE_TEMPLATE/bug.yaml
@@ -4,8 +4,7 @@ labels: [bug]
 body:
   - type: textarea
     attributes:
-      label: actual behavior
-      description: An actual behavior
+      label: Actual behavior
       placeholder: Explain what the problem is and what actually happens
       value: |
         The problem happens when ...
@@ -17,8 +16,7 @@ body:
       required: true
   - type: textarea
     attributes:
-      label: expected behavior
-      description: An expected behavior
+      label: Expected behavior
       placeholder: Explain what the correct behavior should be
       value: |
         No error/warning/crash.
@@ -26,6 +24,5 @@ body:
       required: true
   - type: textarea
     attributes:
-      label: possible fix
-      description: A possible fix
+      label: Possible fix
       placeholder: Explain what can be done to troubleshoot the problem

--- a/.github/ISSUE_TEMPLATE/feature.yaml
+++ b/.github/ISSUE_TEMPLATE/feature.yaml
@@ -4,13 +4,11 @@ labels: [enhancement]
 body:
   - type: textarea
     attributes:
-      label: expected behavior
-      description: An expected behavior
+      label: Expected behavior
       placeholder: Explain what the expected behavior should be
       value: |
         Ability to ...
   - type: textarea
     attributes:
-      label: possible implementation
-      description: A possible implementation
+      label: Possible implementation
       placeholder: Explain what can be done to implement the feature


### PR DESCRIPTION
# Description

Removes descriptions and fixes title's capitalization.

fixes #117 

## Other

- [x] I've read the [contributing guide](../CONTRIBUTING.md).
