### PR TITLE
Feature/144:  Write how to disable YAML extension for GitHub workflow as it conflicts with GitHub Actions extension

### DIFF
--- a/.vscode/ltex.dictionary.en-US.txt
+++ b/.vscode/ltex.dictionary.en-US.txt
@@ -9,3 +9,4 @@ isCollapsed
 ci-status
 yaml
 kra
+json

--- a/.vscode/ltex.hiddenFalsePositives.en-US.txt
+++ b/.vscode/ltex.hiddenFalsePositives.en-US.txt
@@ -25,3 +25,5 @@
 {"rule":"COMMA_PARENTHESIS_WHITESPACE","sentence":"^\\QCurrently, we are not planning to support .\\E$"}
 {"rule":"UPPERCASE_SENTENCE_START","sentence":"^\\Qis not a valid reason to reject proposals.\\E$"}
 {"rule":"COMMA_COMPOUND_SENTENCE","sentence":"^\\QAt the first place, because doing so you deny others work and spent time.\\E$"}
+{"rule":"UPPERCASE_SENTENCE_START","sentence":"^\\Qcontent.\\E$"}
+{"rule":"MORFOLOGIK_RULE_EN_US","sentence":"^\\Qcommon extensions\nYAML:\nYAML (linter, formatter, intellisence, snippets) If you prefer GitHub Actions extension over this one, it's possible to disable YAML extension for workflow files via:\\E$"}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,11 +1,10 @@
 {
-    "yaml.schemas": {
-        "https://json.schemastore.org/hugo.json": "config.yaml",
-        "schemas/repositories.json": "data/repositories.yaml",
-        "schemas/projects.json": "data/projects.yaml",
-        "schemas/extensions.json": "data/extensions.yaml",
-        "schemas/editors.json": "data/editors.yaml",
-        "schemas/support.json": "data/support.yaml",
-        "schemas/empty.json": ".github/workflows/*.yaml"
-    }
+  "yaml.schemas": {
+    "https://json.schemastore.org/hugo.json": "config.yaml",
+    "schemas/repositories.json": "data/repositories.yaml",
+    "schemas/projects.json": "data/projects.yaml",
+    "schemas/extensions.json": "data/extensions.yaml",
+    "schemas/editors.json": "data/editors.yaml",
+    "schemas/support.json": "data/support.yaml"
+  }
 }

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,7 +7,7 @@
 - [common extensions](https://command-line-interface-pages.github.io/site.github.io/extensions/)
 - YAML:
   - [YAML (linter, formatter, intellisence, snippets)](https://marketplace.visualstudio.com/items?itemName=redhat.vscode-yaml)  
-    If you prefer GitHub Actions extension over this one, it's possible
+    If you prefer [GitHub Actions](https://marketplace.visualstudio.com/items?itemName=GitHub.vscode-github-actions) extension over this one, it's possible
     to disable YAML extension for workflow files via:
 
     ```json

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,7 +6,7 @@
 
 - [common extensions](https://command-line-interface-pages.github.io/site.github.io/extensions/)
 - YAML:
-  - [YAML (linter, formatter, intellisence, snippets)](https://marketplace.visualstudio.com/items?itemName=redhat.vscode-yaml)
+  - [YAML (linter, formatter, intellisence, snippets)](https://marketplace.visualstudio.com/items?itemName=redhat.vscode-yaml)  
     If you prefer GitHub Actions extension over this one, it's possible
     to disable YAML extension for workflow files via:
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,6 +5,27 @@
 ### Visual Studio Code
 
 - [common extensions](https://command-line-interface-pages.github.io/site.github.io/extensions/)
+- YAML:
+  - [YAML (linter, formatter, intellisence, snippets)](https://marketplace.visualstudio.com/items?itemName=redhat.vscode-yaml)
+    If you prefer GitHub Actions extension over this one, it's possible
+    to disable YAML extension for workflow files via:
+
+    ```json
+    {
+      "yaml.schemas": {
+        "empty.json": ".github/workflows/*.yaml"
+      }
+    }
+    ```
+
+    where **empty.json** is a schema with:
+
+    ```json
+    {}
+    ```
+
+    content.
+
 - Hugo:
   - [Hugo Language and Syntax Support (snippets, highlighting)](https://marketplace.visualstudio.com/items?itemName=redhat.vscode-yaml)
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,7 +13,7 @@
     ```json
     {
       "yaml.schemas": {
-        "empty.json": ".github/workflows/*.yaml"
+        "schemas/empty.json": ".github/workflows/*.yaml"
       }
     }
     ```


### PR DESCRIPTION
# Description

Adds instructions how to disable YAML extension.

closes #144 

## Other

- [x] I've read the [contributing guide](../CONTRIBUTING.md).
