### PR TITLE
Feature/149: forbid long Bash scripts

### DIFF
--- a/content/guides.md
+++ b/content/guides.md
@@ -319,7 +319,8 @@ several times.
 
 ## Choosing language for scripting
 
-- For continues integration and deployment use Bash (at least 5th).
+- For continues integration and deployment use Bash (at least 5th) until
+  scripts are longer than 200 lines (including empty ones).
 - For CLIP page parsers/renderers/converters/explainers use Go.
 
 Currently, our toolkit is written in Bash. Even so, it doesn't mean

--- a/content/guides.md
+++ b/content/guides.md
@@ -323,7 +323,7 @@ several times.
   scripts are longer than 200 lines (including empty ones).
 - For CLIP page parsers/renderers/converters/explainers use Go.
 - Plain code in `sed`, `awk`, `jq`, `yq` is not allowed, it always must be
-  embedded in Bash script.
+  embedded in a Bash script.
 
 Currently, our toolkit is written in Bash. Even so, it doesn't mean
 that rules above can be violated. In other words, we are going to rewrite this

--- a/content/guides.md
+++ b/content/guides.md
@@ -322,6 +322,8 @@ several times.
 - For continues integration and deployment use Bash (at least 5th) until
   scripts are longer than 200 lines (including empty ones).
 - For CLIP page parsers/renderers/converters/explainers use Go.
+- Plain code in `sed`, `awk`, `jq`, `yq` is not allowed, it always must be
+  embedded in Bash script.
 
 Currently, our toolkit is written in Bash. Even so, it doesn't mean
 that rules above can be violated. In other words, we are going to rewrite this


### PR DESCRIPTION
# Description

Removes ability to write long Bash scripts and standalone sed, awk, jq, yq ones.

closes #149 

## Other

- [x] I've read the [contributing guide](../CONTRIBUTING.md).
